### PR TITLE
Major code optimization

### DIFF
--- a/src/allocate.c
+++ b/src/allocate.c
@@ -2,11 +2,11 @@
 
 chunk_t heap;
 
+void* allocate(const unsigned long long size) {
 	chunk_t* chunk = &heap;
 
-	while (chunk->next != 0) {
+	while (chunk->next != 0)
 		chunk = chunk->next;
-	}
 
 	chunk->next = chunk + sizeof(chunk_t) + chunk->size;
 	chunk->next->prev = chunk;

--- a/src/allocate.c
+++ b/src/allocate.c
@@ -1,6 +1,7 @@
 #include "littlememory.h"
 
-void* allocate(unsigned long long size) {
+chunk_t heap;
+
 	chunk_t* chunk = &heap;
 
 	while (chunk->next != 0) {

--- a/src/deallocate.c
+++ b/src/deallocate.c
@@ -1,6 +1,6 @@
 #include "littlememory.h"
 
-void deallocate(void* ptr) {
+void deallocate(void* restrict ptr) {
 	chunk_t* chunk = (chunk_t*) (ptr - sizeof(chunk_t));
 
 	if (chunk->next == 0 || chunk->prev) return;

--- a/src/littlememory.h
+++ b/src/littlememory.h
@@ -7,8 +7,6 @@ typedef struct chunk_t {
 	struct chunk_t* prev;
 } chunk_t;
 
-chunk_t heap;
-
 void* allocate(unsigned long long);
 void deallocate(void*);
 void reallocate(void*, unsigned long long);

--- a/src/reallocate.c
+++ b/src/reallocate.c
@@ -1,6 +1,6 @@
 #include "littlememory.h"
 
-void reallocate(void* ptr, unsigned long long size) {
+void reallocate(void* restrict ptr, const unsigned long long size) {
 	chunk_t* chunk = (chunk_t*) (ptr - sizeof(chunk_t));
 
 	if (chunk->next == 0) return;

--- a/src/set.c
+++ b/src/set.c
@@ -1,7 +1,7 @@
 #include "littlememory.h"
 
-void* set(void* ptr, unsigned char value, unsigned long long size) {
-	int i = 0;
+void* set(void* restrict ptr, const unsigned char value, const unsigned long long size) {
+	unsigned int i = 0;
 
 	unsigned char* p = (unsigned char*) ptr;
 


### PR DESCRIPTION
Some of the code could be optimized and so patched, I brought here a few patches for the code.

Some of the patches is using `const` for the integers as it does make more sense as the size will be a constant and not change the same for void pointers that could have a restricted they are not constants but they don't need to be stored and be used, they can be used right away so there is where `restrict` joins and reduces an instruction.

More information can be found in the C documentation and in the commit messages.
